### PR TITLE
Add derivation to build unison trunk with cabal

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,7 +1,11 @@
-{ sources ? import ./sources.nix, pkgs ? import sources.nixpkgs {} }:
+{ sources ? import ./sources.nix, pkgs ? import sources.nixpkgs { config.allowBroken = true; } }:
 
 {
   unison-ucm = pkgs.callPackage ./ucm.nix {};
+
+  unison = pkgs.callPackage ./unison-cabal.nix {
+    inherit sources;
+  };
 
   vim-unison = pkgs.callPackage ./vim-unison.nix {
     inherit (pkgs.vimUtils) buildVimPluginFrom2Nix;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,22 +5,22 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "9d35b9e4837ab88517210b1701127612c260eccf",
-        "sha256": "0q50xhnm8g2yfyakrh0nly4swyygxpi0a8cb9gp65wcakcgvzvdh",
+        "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
+        "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/9d35b9e4837ab88517210b1701127612c260eccf.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "release-20.03",
+        "branch": "nixpkgs-unstable",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "067d8e6c9f4ad3df62d4c9359865747aedea8853",
-        "sha256": "16lgiy1zn3nms17xhgp28a8vpfjpw9kcpi95hfdax1zj94fkcvaa",
+        "rev": "5df05c902cde398e056eb6271d5fe13e418db4c6",
+        "sha256": "12plc7k251z1dmmrd29lyrpw0xmjvmf79yj568aapzrcki5mrw74",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/067d8e6c9f4ad3df62d4c9359865747aedea8853.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5df05c902cde398e056eb6271d5fe13e418db4c6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unison": {
@@ -29,10 +29,10 @@
         "homepage": "https://unisonweb.org",
         "owner": "unisonweb",
         "repo": "unison",
-        "rev": "1c880c064a5435077638eed5962b422eb6a358a1",
-        "sha256": "1ywqi4m4k440gnqh1irkrkiw9pnzrwl0xzjan00zpsnq6cg9xyw1",
+        "rev": "2b83c963f40a5af035a6c0048ad29d68f1c75e37",
+        "sha256": "1n1s8dj0nnp241yqw4xzvxamkdv1skikawgi9plh6ag1ncnj0jxj",
         "type": "tarball",
-        "url": "https://github.com/unisonweb/unison/archive/1c880c064a5435077638eed5962b422eb6a358a1.tar.gz",
+        "url": "https://github.com/unisonweb/unison/archive/2b83c963f40a5af035a6c0048ad29d68f1c75e37.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,28 @@
 {
+    "haskeline": {
+        "branch": "unison",
+        "description": "A Haskell library for line input in command-line programs.",
+        "homepage": "  https://hackage.haskell.org/package/haskeline",
+        "owner": "unisonweb",
+        "repo": "haskeline",
+        "rev": "2944b11d19ee034c48276edc991736105c9d6143",
+        "sha256": "02ia83gjq3kssj4kx8a6673q62m65zd6hipazmfvhzps3yvfyvx7",
+        "type": "tarball",
+        "url": "https://github.com/unisonweb/haskeline/archive/2944b11d19ee034c48276edc991736105c9d6143.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "megaparsec": {
+        "branch": "unison",
+        "description": "Industrial-strength monadic parser combinator library",
+        "homepage": "",
+        "owner": "unisonweb",
+        "repo": "megaparsec",
+        "rev": "c4463124c578e8d1074c04518779b5ce5957af6b",
+        "sha256": "1a7b9s4j76c8k8gz6r2jidkb8yqpj0rgn9qdkj14jymjcpa3gmgd",
+        "type": "tarball",
+        "url": "https://github.com/unisonweb/megaparsec/archive/c4463124c578e8d1074c04518779b5ce5957af6b.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -6,25 +6,33 @@ let
   # The fetchers. fetch_<type> fetches specs of type <type>.
   #
 
-  fetch_file = pkgs: spec:
-    if spec.builtin or true then
-      builtins_fetchurl { inherit (spec) url sha256; }
-    else
-      pkgs.fetchurl { inherit (spec) url sha256; };
+  fetch_file = pkgs: name: spec:
+    let
+      name' = sanitizeName name + "-src";
+    in
+      if spec.builtin or true then
+        builtins_fetchurl { inherit (spec) url sha256; name = name'; }
+      else
+        pkgs.fetchurl { inherit (spec) url sha256; name = name'; };
 
   fetch_tarball = pkgs: name: spec:
     let
-      ok = str: ! builtins.isNull (builtins.match "[a-zA-Z0-9+-._?=]" str);
-      # sanitize the name, though nix will still fail if name starts with period
-      name' = stringAsChars (x: if ! ok x then "-" else x) "${name}-src";
+      name' = sanitizeName name + "-src";
     in
       if spec.builtin or true then
         builtins_fetchTarball { name = name'; inherit (spec) url sha256; }
       else
         pkgs.fetchzip { name = name'; inherit (spec) url sha256; };
 
-  fetch_git = spec:
-    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+  fetch_git = name: spec:
+    let
+      ref =
+        if spec ? ref then spec.ref else
+          if spec ? branch then "refs/heads/${spec.branch}" else
+            if spec ? tag then "refs/tags/${spec.tag}" else
+              abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+    in
+      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
 
   fetch_local = spec: spec.path;
 
@@ -40,11 +48,21 @@ let
   # Various helpers
   #
 
+  # https://github.com/NixOS/nixpkgs/pull/83241/files#diff-c6f540a4f3bfa4b0e8b6bafd4cd54e8bR695
+  sanitizeName = name:
+    (
+      concatMapStrings (s: if builtins.isList s then "-" else s)
+        (
+          builtins.split "[^[:alnum:]+._?=-]+"
+            ((x: builtins.elemAt (builtins.match "\\.*(.*)" x) 0) name)
+        )
+    );
+
   # The set of packages used when specs are fetched using non-builtins.
-  mkPkgs = sources:
+  mkPkgs = sources: system:
     let
       sourcesNixpkgs =
-        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) {};
+        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) { inherit system; };
       hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
       hasThisAsNixpkgsPath = <nixpkgs> == ./.;
     in
@@ -64,14 +82,26 @@ let
 
     if ! builtins.hasAttr "type" spec then
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
-    else if spec.type == "file" then fetch_file pkgs spec
+    else if spec.type == "file" then fetch_file pkgs name spec
     else if spec.type == "tarball" then fetch_tarball pkgs name spec
-    else if spec.type == "git" then fetch_git spec
+    else if spec.type == "git" then fetch_git name spec
     else if spec.type == "local" then fetch_local spec
     else if spec.type == "builtin-tarball" then fetch_builtin-tarball name
     else if spec.type == "builtin-url" then fetch_builtin-url name
     else
       abort "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
+
+  # If the environment variable NIV_OVERRIDE_${name} is set, then use
+  # the path directly as opposed to the fetched source.
+  replace = name: drv:
+    let
+      saneName = stringAsChars (c: if isNull (builtins.match "[a-zA-Z0-9]" c) then "_" else c) name;
+      ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
+    in
+      if ersatz == "" then drv else
+        # this turns the string into an actual Nix path (for both absolute and
+        # relative paths)
+        if builtins.substring 0 1 ersatz == "/" then /. + ersatz else /. + builtins.getEnv "PWD" + "/${ersatz}";
 
   # Ports of functions for older nix versions
 
@@ -89,25 +119,29 @@ let
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L269
   stringAsChars = f: s: concatStrings (map f (stringToCharacters s));
+  concatMapStrings = f: list: concatStrings (map f list);
   concatStrings = builtins.concatStringsSep "";
 
+  # https://github.com/NixOS/nixpkgs/blob/8a9f58a375c401b96da862d969f66429def1d118/lib/attrsets.nix#L331
+  optionalAttrs = cond: as: if cond then as else {};
+
   # fetchTarball version that is compatible between all the versions of Nix
-  builtins_fetchTarball = { url, name, sha256 }@attrs:
+  builtins_fetchTarball = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchTarball;
     in
       if lessThan nixVersion "1.12" then
-        fetchTarball { inherit name url; }
+        fetchTarball ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
       else
         fetchTarball attrs;
 
   # fetchurl version that is compatible between all the versions of Nix
-  builtins_fetchurl = { url, sha256 }@attrs:
+  builtins_fetchurl = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchurl;
     in
       if lessThan nixVersion "1.12" then
-        fetchurl { inherit url; }
+        fetchurl ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
       else
         fetchurl attrs;
 
@@ -119,14 +153,15 @@ let
         then abort
           "The values in sources.json should not have an 'outPath' attribute"
         else
-          spec // { outPath = fetch config.pkgs name spec; }
+          spec // { outPath = replace name (fetch config.pkgs name spec); }
     ) config.sources;
 
   # The "config" used by the fetchers
   mkConfig =
-    { sourcesFile ? ./sources.json
-    , sources ? builtins.fromJSON (builtins.readFile sourcesFile)
-    , pkgs ? mkPkgs sources
+    { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
+    , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
+    , system ? builtins.currentSystem
+    , pkgs ? mkPkgs sources system
     }: rec {
       # The sources, i.e. the attribute set of spec name to spec
       inherit sources;
@@ -134,5 +169,6 @@ let
       # The "pkgs" (evaluated nixpkgs) to use for e.g. non-builtin fetchers
       inherit pkgs;
     };
+
 in
 mkSources (mkConfig {}) // { __functor = _: settings: mkSources (mkConfig settings); }

--- a/nix/unison-cabal.nix
+++ b/nix/unison-cabal.nix
@@ -1,0 +1,22 @@
+{ sources, pkgs, haskellPackages, haskell }:
+let
+  inherit (haskell.lib) dontCheck doJailbreak overrideCabal;
+  overrides =
+    self: super: {
+      easytest = self.callCabal2nix "easytest" "${sources.unison}/yaks/easytest" {};
+      unison-core = doJailbreak (self.callCabal2nix "unison-core" "${sources.unison}/unison-core" {});
+      unison-parser-typechecker = overrideCabal (doJailbreak (self.callCabal2nix "unison-parser-typechecker" "${sources.unison}/parser-typechecker" {}))
+        {
+          configureFlags = [ "--constraint=haskeline==0.7.5.0" ];
+        };
+      random = dontCheck self.random_1_2_0;
+      hashable = doJailbreak super.hashable;
+      unicode-show = dontCheck super.unicode-show;
+      megaparsec = dontCheck (doJailbreak (self.callCabal2nix "megaparsec" sources.megaparsec {}));
+      haskeline = doJailbreak (self.callCabal2nix "haskeline" sources.haskeline {});
+    };
+  myHaskellPackages = haskellPackages.override {
+    inherit overrides;
+  };
+in
+myHaskellPackages.unison-parser-typechecker


### PR DESCRIPTION
I have found a way to build unison trunk with a current nixpkgs.

Sadly because of the random >= 1.2.0 constraint you get _a lot_ of cache misses.

Some of the packages we depend on needed some fixing and are marked broken in nixpkgs.

I can can churn through them and fix them in the next days in nixpkgs. (I am a nixpkgs haskellPackages maintainer.)

I would in principle like very much to get this back into nixpkgs (and could maintain it there) but I am not really inclined to do so as long as we depend on these haskeline and megaparsec forks.

I am also blatantly overriding the `containers >= 6.3.0` constraint here. I am sure it has a reason, but it compiles without that. (Und bumping containers would again mean rebuilding 160 packages.)