### PR TITLE
cachix-install-nix-action v11 -> v12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v11
+    - uses: cachix/install-nix-action@v12
     - run: |
         nix-env -f default.nix -i -A unison-ucm
         ucm --version


### PR DESCRIPTION
Hopefully this fixes the GitHub Action CI.