### PR TITLE
add ncurses dependency back in

### DIFF
--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -1,4 +1,4 @@
-{ autoPatchelfHook, fzf, glibcLocales, git, gmp, less, mkShell, ormolu, stack, stdenv, darwin, zlib }:
+{ autoPatchelfHook, fzf, glibcLocales, git, gmp, less, mkShell, ncurses, ormolu, stack, stdenv, darwin, zlib }:
 
 mkShell {
   description = "Support for developing the compiler/tooling for the Unison programming language";
@@ -10,6 +10,7 @@ mkShell {
   buildInputs = [
     git
     less
+    ncurses
     zlib
     zlib.dev
     zlib.out

--- a/nix/ucm.nix
+++ b/nix/ucm.nix
@@ -33,6 +33,7 @@
 , less
 , lib
 , makeWrapper
+, ncurses
 , stdenv
 , zlib
 }:
@@ -68,7 +69,7 @@ stdenv.mkDerivation rec {
   doInstallCheck = true;
 
   nativeBuildInputs = [ installShellFiles makeWrapper ] ++ lib.optional (!stdenv.isDarwin) autoPatchelfHook;
-  buildInputs = [ git less fzf zlib ] ++ lib.optionals (!stdenv.isDarwin) [ gmp ];
+  buildInputs = [ git less fzf ncurses zlib ] ++ lib.optionals (!stdenv.isDarwin) [ gmp ];
 
   binPath = lib.makeBinPath buildInputs;
 


### PR DESCRIPTION
I was getting missing `libtinfo` dependency error messages.