### PR TITLE
dev-shell: rm zlib.dev and zlib.out

### DIFF
--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -12,8 +12,6 @@ mkShell {
     less
     ncurses
     zlib
-    zlib.dev
-    zlib.out
     fzf
     glibcLocales
     gmp


### PR DESCRIPTION
I added these when I was flailing with some build issues. They don't
seem to make a difference.

I think that there is still an issue with the zlib dependency, because
when I try to build with `stack --nix-pure` I get:

```
/nix/store/cimp3vp40msz4afq1c3602p2rn9bff0d-binutils-2.35.2/bin/ld.gold: error: cannot find -lz
```

But I can't figure it out, so I'm just not adding the `--nix-pure` flag
for now.
