### PR TITLE
build-from-transcript: include transcript hash in derivation name

### DIFF
--- a/nix/build-from-transcript.nix
+++ b/nix/build-from-transcript.nix
@@ -9,7 +9,8 @@
 
 let
   compiled = stdenv.mkDerivation {
-    pname = pname + "_ucm-${unison-ucm.version}";
+    # include the ucm version and transcript hash in the derivation name so it is rebuilt if either changes
+    pname = pname + "_ucm-${unison-ucm.version}_${builtins.hashFile "sha256" src}";
     inherit version;
 
     nativeBuildInputs = [ cacert ];


### PR DESCRIPTION
So it is rebuilt if the transcript content changes.
