### PR TITLE
Simplify `darwin-security-hack` dependency

### DIFF
--- a/nix/darwin-security-hack.nix
+++ b/nix/darwin-security-hack.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation {
     description = "A hack to add /usr/bin/security to the PATH for darwin builds";
     license = with licenses; [mit bsd3];
     maintainers = [maintainers.ceedubs];
-    platforms = ["x86_64-darwin" "x86_64-linux"];
+    platforms = lib.platforms.darwin;
   };
 }

--- a/nix/ucm.nix
+++ b/nix/ucm.nix
@@ -25,7 +25,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   autoPatchelfHook,
-  darwin-security-hack ? null,
+  darwin-security-hack,
   fetchurl,
   fzf,
   git,
@@ -74,15 +74,12 @@ in
 
     nativeBuildInputs = [installShellFiles makeWrapper] ++ lib.optional (!stdenv.isDarwin) autoPatchelfHook;
 
-    darwinBuildInputs = lib.optional (darwin-security-hack != null) darwin-security-hack;
-    nonDarwinBuildInputs = [gmp];
-
     buildInputs =
       [git less fzf ncurses zlib]
       ++ (
         if (stdenv.isDarwin)
-        then darwinBuildInputs
-        else nonDarwinBuildInputs
+        then [darwin-security-hack]
+        else [gmp]
       );
 
     binPath = lib.makeBinPath buildInputs;


### PR DESCRIPTION
Nix is lazy, but adding an unknown attribute to a derivation forces its value,
because it is stringified into the build environment, necessitating extra
conditionals.

This also adjusts the platforms for `darwin-security-hack` to remove linux and
add remaining darwin platforms.