### PR TITLE
Restructure package sets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,54 +16,56 @@
   }: let
     systems = flake-utils.lib.defaultSystems;
 
-    overlay = final: prev: {
-      darwin-security-hack = final.callPackage ./nix/darwin-security-hack.nix {};
+    localPackages = pkgs: let
+      darwin-security-hack = pkgs.callPackage ./nix/darwin-security-hack.nix {};
+    in {
+      ucm = pkgs.callPackage ./nix/ucm.nix {inherit darwin-security-hack;};
 
-      unison-ucm = final.callPackage ./nix/ucm.nix {};
+      prep-unison-scratch = pkgs.callPackage ./nix/prep-unison-scratch {};
 
-      prep-unison-scratch = final.callPackage ./nix/prep-unison-scratch {};
-
-      vimPlugins =
-        prev.vimPlugins
-        // {
-          vim-unison = final.vimUtils.buildVimPlugin {
-            name = "vim-unison";
-            src = unison + "/editor-support/vim";
-          };
-        };
+      vim-unison = pkgs.vimUtils.buildVimPlugin {
+        name = "vim-unison";
+        src = unison + "/editor-support/vim";
+      };
     };
   in
     flake-utils.lib.eachSystem systems
     (
       system: let
-        isDarwin = sys:
-          builtins.match ".*darwin" sys != null;
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [overlay];
-        };
-        ucm = pkgs.unison-ucm;
+        pkgs = import nixpkgs {inherit system;};
       in {
-        packages = rec {
-          inherit ucm;
+        packages =
+          {default = self.packages.${system}.ucm;} // localPackages pkgs;
 
-          vim-unison = pkgs.vimPlugins.vim-unison;
-
-          inherit (pkgs) prep-unison-scratch;
-        };
-
-        defaultPackage = ucm;
+        ## Deprecated
+        defaultPackage = self.packages.${system}.default;
 
         formatter = pkgs.alejandra;
       }
     )
     // {
-      inherit overlay;
+      overlays = {
+        default = final: prev: let
+          localPkgs = localPackages final;
+        in {
+          inherit (localPkgs) prep-unison-scratch;
+
+          ## Renamed to replace the `unison-ucm` included in Nixpkgs.
+          unison-ucm = localPkgs.ucm;
+
+          vimPlugins = prev.vimPlugins // self.overlays.vim final prev;
+        };
+
+        vim = final: prev: {inherit (localPackages final) vim-unison;};
+      };
+
+      ## Deprecated
+      overlay = self.overlays.default;
 
       lib = let
         buildUnisonFromTranscript = pkgs:
           pkgs.callPackage ./nix/build-from-transcript.nix {
-            inherit (overlay pkgs pkgs) unison-ucm;
+            inherit (localPackages pkgs) ucm;
           };
       in {
         inherit buildUnisonFromTranscript;

--- a/nix/build-from-transcript.nix
+++ b/nix/build-from-transcript.nix
@@ -3,7 +3,7 @@
   lib,
   makeWrapper,
   stdenv,
-  unison-ucm,
+  ucm,
 }: {
   pname,
   version,
@@ -36,13 +36,13 @@
 }: let
   compiled = stdenv.mkDerivation {
     # include the ucm version and transcript hash in the derivation name so it is rebuilt if either changes
-    pname = pname + "_ucm-${unison-ucm.version}_${builtins.hashFile "sha256" src}";
+    pname = pname + "_ucm-${ucm.version}_${builtins.hashFile "sha256" src}";
     inherit version;
 
     nativeBuildInputs = [cacert];
     buildCommand = ''
       export XDG_DATA_HOME="$TMP/.local/share"
-      ${unison-ucm}/bin/ucm -C . transcript ${src}
+      ${ucm}/bin/ucm -C . transcript ${src}
       mkdir -p $out/share
       mv *.uc $out/share/
     '';
@@ -60,7 +60,7 @@ in
       mkdir -p $out/bin
 
       for ucFile in ${compiled}/share/*.uc; do
-        makeWrapper "${unison-ucm}/bin/ucm" "$out/bin/$(basename "$ucFile" .uc)" \
+        makeWrapper "${ucm}/bin/ucm" "$out/bin/$(basename "$ucFile" .uc)" \
           --add-flags "run.compiled $ucFile"
       done
     '';


### PR DESCRIPTION
Pull a common `localPackages` out of the `overlay` and `packages` outputs, and
rebuild them.

This also adds the standard `overlays` output in addition to the deprecated
`overlay` output. It also adds a `vim` overlay for the Vim plugin and removes
`darwin-security-hack` from the overlays.