### PR TITLE
Add tree-sitter and Emacs support to the outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,15 +79,17 @@
         };
 
         emacs = final: prev: efinal: eprev: {
-          unison-ts-mode = efinal.trivialBuild {
+          unison-ts-mode = let
+            version = "1.0.0-rc.2";
+          in efinal.trivialBuild {
+            inherit version;
             pname = "unison-ts-mode";
-            version = "1.0.0-rc.1";
 
             src = final.fetchFromGitHub {
               owner = "fmguerreiro";
               repo = "unison-ts-mode";
-              rev = "main";
-              sha256 = "GwF5//vnrdANGWz8gDv7Oi79UDGej88VXtnalV85f6o=";
+              rev = "v${version}";
+              sha256 = "R3A1z8wzhDCy3KGZ7ZMbAed3VmKwdExsUyxD2X8ZtoM=";
             };
           };
         };


### PR DESCRIPTION
This provides tree-sitter and Emacs entries in the default overlay, and shows example usage in the home configuration.

As these things find their way into the usual distribution models (nixpkgs for tree-sitter and [MELPA](https://melpa.org/) for Emacs’ unison-ts-mode), they can be removed from the flake. For now, installing them manually can be a bit of a pain, so this helps with that for Nix users.