### PR TITLE
add curl to library path

### DIFF
--- a/nix/ucm.nix
+++ b/nix/ucm.nix
@@ -36,6 +36,7 @@
   libb2,
   makeWrapper,
   ncurses,
+  curl,
   openssl,
   stdenv,
   zlib,
@@ -93,7 +94,7 @@ in
 
       makeWrapper $out/unison/unison ${ucm} \
         --prefix PATH : ${binPath} \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libb2 openssl ]} \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libb2 openssl curl ]} \
         --add-flags "--runtime-path $out/lib/runtime/bin/unison-runtime" \
         --set-default UCM_WEB_UI "$out/ui"
     '';


### PR DESCRIPTION
This fixed the following error I got on Fedora KDE 40:

```
kde-open: /nix/store/k3d7ny5h682kixy91iw7sm653kxyqr8d-openssl-3.0.12/lib/libssl.so.3: version `OPENSSL_3.2.0' not found (required by /lib64/libcurl.so.4)
```