### PR TITLE
ucm 0.5.28 and aarch64-darwin support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,11 @@ jobs:
   test_ucm:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-13]
+        platform: [ubuntu-24.04, macos-13, macos-14]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - uses: cachix/install-nix-action@6004951b182f8860210c8d6f0d808ec5b1a33d28
     - run: |
         nix-build default.nix -A unison-ucm
-        PATH='' ./result/bin/ucm version
-        echo "pull stew.public.projects.uuid.latest lib.uuid" | \
-          PATH='' ./result/bin/ucm
+        PATH='' ./result/bin/ucm --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,14 @@ jobs:
         platform: [ubuntu-24.04, macos-13, macos-14]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-    - uses: cachix/install-nix-action@6004951b182f8860210c8d6f0d808ec5b1a33d28
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: nixbuild/nix-quick-install-action@25aff27c252e0c8cdda3264805f7b6bcd92c8718 # # v29
+    - uses: nix-community/cache-nix-action@8351fb9f51c580c96c509987ebb99e38aed956ce # 5.2.1
+      with:
+        # restore and save a cache using this key
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+        # if there's no cache hit, restore a cache by this prefix
+        restore-prefixes-first-match: nix-${{ runner.os }}-
     - run: |
         nix-build default.nix -A unison-ucm
         PATH='' ./result/bin/ucm --version

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720042825,
-        "narHash": "sha256-A0vrUB6x82/jvf17qPCpxaM+ulJnD8YZwH9Ci0BsAzE=",
+        "lastModified": 1726989464,
+        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e1391fb22e18a36f57e6999c7a9f966dc80ac073",
+        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723282977,
-        "narHash": "sha256-oTK91aOlA/4IsjNAZGMEBz7Sq1zBS0Ltu4/nIQdYDOg=",
+        "lastModified": 1731797254,
+        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a781ff33ae258bbcfd4ed6e673860c3e923bf2cc",
+        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
     "unison": {
       "flake": false,
       "locked": {
-        "lastModified": 1723264652,
-        "narHash": "sha256-weap+RTXcYSrcM+aLEaDYRjkkZYvN0M2fZPOami7rrA=",
+        "lastModified": 1732304137,
+        "narHash": "sha256-JCYRtipC17WpEWeJ279WolhCoasfpAJSBgo0CBP9Ssg=",
         "owner": "unisonweb",
         "repo": "unison",
-        "rev": "d5d9d9d9ab6a925a9a35f658016b8b76236d36e3",
+        "rev": "d7a1edbdf51b88f8d01d1bc279ec811245f5256d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,6 @@
         default = final: prev: let
           localPkgs = localPackages final;
         in {
-
           emacsPackagesFor = emacs:
             (prev.emacsPackagesFor emacs).overrideScope'
             (self.overlays.emacs final prev);
@@ -78,17 +77,18 @@
         emacs = final: prev: efinal: eprev: {
           unison-ts-mode = let
             version = "1.0.0-rc.2";
-          in efinal.trivialBuild {
-            inherit version;
-            pname = "unison-ts-mode";
+          in
+            efinal.trivialBuild {
+              inherit version;
+              pname = "unison-ts-mode";
 
-            src = final.fetchFromGitHub {
-              owner = "fmguerreiro";
-              repo = "unison-ts-mode";
-              rev = "v${version}";
-              sha256 = "R3A1z8wzhDCy3KGZ7ZMbAed3VmKwdExsUyxD2X8ZtoM=";
+              src = final.fetchFromGitHub {
+                owner = "fmguerreiro";
+                repo = "unison-ts-mode";
+                rev = "v${version}";
+                sha256 = "R3A1z8wzhDCy3KGZ7ZMbAed3VmKwdExsUyxD2X8ZtoM=";
+              };
             };
-          };
         };
 
         vim = final: prev: {inherit (localPackages final) vim-unison;};
@@ -183,6 +183,6 @@
             })
           ];
         };
-      }) ["x86_64-darwin" "x86_64-linux"]);
+      }) ["aarch64-darwin" "x86_64-darwin" "x86_64-linux"]);
     };
 }

--- a/nix/ucm.nix
+++ b/nix/ucm.nix
@@ -39,34 +39,41 @@
   curl,
   openssl,
   stdenv,
+  system,
   zlib,
 }: let
+  version = "0.5.28";
+
+  # sha256 can be calculated with `nix-prefetch-url <url>`. For example:
+  # nix-prefetch-url https://github.com/unisonweb/unison/releases/download/release/0.5.28/ucm-linux-x64.tar.gz
+  srcForPlatform = {
+    aarch64-darwin = {
+      sys = "macos-arm64";
+      sha256 = "0h1visfw23ny56j0z5s0f88riivzwjrfmxlkignach0qhnlq6kwi";
+    };
+    x86_64-darwin = {
+      sys = "macos-x64";
+      sha256 = "1l6a7sibhdqbcmgj0y6nwkiq5fljbllglc4dvvzhy7jlq6xp3bcm";
+    };
+    x86_64-linux = {
+      sys = "linux-x64";
+      sha256 = "0jma0vdh5dqsxbwi5yzini4pac1gzz8pwfwwgr82mpyr16m3a703";
+    };
+  };
+
+  src = let
+    srcArgs = srcForPlatform.${system};
+  in
+    fetchurl {
+      url = "https://github.com/unisonweb/unison/releases/download/release/${version}/ucm-${srcArgs.sys}.tar.gz";
+      inherit (srcArgs) sha256;
+    };
+
   ucm = "$out/bin/ucm";
 in
   stdenv.mkDerivation rec {
     pname = "unison-code-manager";
-    version = "0.5.27";
-
-    src = let
-      srcUrl = os: "https://github.com/unisonweb/unison/releases/download/release/${version}/ucm-${os}.tar.gz";
-
-      # sha256 can be calculated with `nix-prefetch-url <url>`. For example:
-      # nix-prefetch-url https://github.com/unisonweb/unison/releases/download/release/0.5.13/ucm-linux.tar.gz
-      srcArgs =
-        if (stdenv.isDarwin)
-        then {
-          os = "macos";
-          sha256 = "1id7ywyqbphcgniywmqnvnbfx55jy807z0ni7ycl2zl23yijcqbf";
-        }
-        else {
-          os = "linux";
-          sha256 = "101jl2jr95jlscs41hc6sfn5zmlff22b03alryx1qjjh6a1wrklf";
-        };
-    in
-      fetchurl {
-        url = srcUrl srcArgs.os;
-        inherit (srcArgs) sha256;
-      };
+    inherit src version;
 
     # The tarball is just the prebuilt binary, in the archive root.
     sourceRoot = ".";
@@ -94,7 +101,7 @@ in
 
       makeWrapper $out/unison/unison ${ucm} \
         --prefix PATH : ${binPath} \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libb2 openssl curl ]} \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [libb2 openssl curl]} \
         --add-flags "--runtime-path $out/lib/runtime/bin/unison-runtime" \
         --set-default UCM_WEB_UI "$out/ui"
     '';
@@ -120,7 +127,7 @@ in
       homepage = "https://unisonweb.org/";
       license = with licenses; [mit bsd3];
       maintainers = [maintainers.ceedubs];
-      platforms = ["x86_64-darwin" "x86_64-linux"];
+      platforms = attrNames srcForPlatform;
       mainProgram = "ucm";
     };
   }


### PR DESCRIPTION
- **Flake update**
- **ucm 0.5.28 with support for aarch64-darwin**
- **Set up Nix caching for GitHub Actions**
