### PR TITLE
ucm: 0.5.36 -> 0.5.37

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -733,16 +733,16 @@
         "nixpkgs-release": "nixpkgs-release"
       },
       "locked": {
-        "lastModified": 1741390134,
-        "narHash": "sha256-BrYiVurIN7WqqH0RdUSKWl5G8Qeuc7Y45csQUVCtoSU=",
+        "lastModified": 1743131295,
+        "narHash": "sha256-/aBYP+4pgjJGJHB8BZRexsDZbxaouuSSdG9Gl3M97aw=",
         "owner": "unisonweb",
         "repo": "unison",
-        "rev": "8fe5adc774f2bef81a6866d8c0142df3c904829e",
+        "rev": "51d6d80ead4325a5d491a795a413b82d4af6d35a",
         "type": "github"
       },
       "original": {
         "owner": "unisonweb",
-        "ref": "release/0.5.36",
+        "ref": "release/0.5.37",
         "repo": "unison",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       ## NB: Before upgrading this, make sure the release you upgrade to is
       ##     pinned in the cache (https://app.cachix.org/cache/unison#pins) for
       ##     all supported systems.
-      url = "github:unisonweb/unison/release/0.5.36";
+      url = "github:unisonweb/unison/release/0.5.37";
     };
   };
 

--- a/nix/ucm.nix
+++ b/nix/ucm.nix
@@ -42,22 +42,22 @@
   system,
   zlib,
 }: let
-  version = "0.5.36";
+  version = "0.5.37";
 
   # hash can be calculated with `nix store prefetch-file <url>`. For example:
   # nix store prefetch-file https://github.com/unisonweb/unison/releases/download/release/0.5.34/ucm-linux-x64.tar.gz
   srcForPlatform = {
     aarch64-darwin = {
       sys = "macos-arm64";
-      hash = "sha256-GH0qZtb29qDxL39nArYSzCQ50/ssPOiN9CXnAvb9uVQ=";
+      hash = "sha256-cqsh1/H31ibyA8yr6pNdRAaH1nidobzt77oJq1N2icQ=";
     };
     x86_64-darwin = {
       sys = "macos-x64";
-      hash = "sha256-seL8Ey20KYVsOLugGvfVXXIIVdv7q04PYXh3c6MoZDk=";
+      hash = "sha256-9a8TJK6D5BU5TugQmYEcaFv5Hu9eeD463g23aSyKKQU=";
     };
     x86_64-linux = {
       sys = "linux-x64";
-      hash = "sha256-Zb91ixXd3ueQj6+YjC9Wgq3PnfcKBKZZdCJfS0nQOV4=";
+      hash = "sha256-eAqaE38M/spM3t0Ar/sJwGNPaNT/P9Lfn2ZIsW75kS8=";
     };
   };
 


### PR DESCRIPTION
The new release is in the Unison Nix cache, so this updates both the source and binary derivations.