### PR TITLE
Upgrade the UCM source derivations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       ## NB: Before upgrading this, make sure the release you upgrade to is
       ##     pinned in the cache (https://app.cachix.org/cache/unison#pins) for
       ##     all supported systems.
-      url = "github:unisonweb/unison/release/0.5.37";
+      url = "github:unisonweb/unison/release/0.5.40";
     };
   };
 

--- a/nix/ucm.nix
+++ b/nix/ucm.nix
@@ -42,6 +42,7 @@
   system,
   zlib,
 }: let
+  ## NB: When changing this, also change `inputs.unison.url` in flake.nix.
   version = "0.5.40";
 
   # hash can be calculated with `nix store prefetch-file <url>`. For example:


### PR DESCRIPTION
They had fallen behind the binaries, so this goes from 0.5.37 to 0.5.40.