### PR TITLE
Fail CI if flake.lock is out of date

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         nix-build default.nix -A unison-ucm
         PATH='' ./result/bin/ucm --version
     - run: |
-        nix build .#ucm
+        nix build --no-update-lock-file .#ucm
         PATH='' ./result/bin/unison --version
   test_homeConfiguration:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This will pass CI once #132 is merged.