### PR TITLE
Update transcript syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,18 @@ on:
   pull_request:
   push:
 jobs:
+  check_flake:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: nixbuild/nix-quick-install-action@25aff27c252e0c8cdda3264805f7b6bcd92c8718 # # v29
+    - uses: nix-community/cache-nix-action@8351fb9f51c580c96c509987ebb99e38aed956ce # 5.2.1
+      with:
+        # restore and save a cache using this key
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+        # if there's no cache hit, restore a cache by this prefix
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+    - run: nix flake check
   test_ucm:
     strategy:
       matrix:

--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,30 @@
         ## Deprecated
         defaultPackage = self.packages.${system}.default;
 
+        checks = {
+          # A simple example: create an executable from a Unison Share project
+          snake = let
+            newPkgs = pkgs.appendOverlays [self.overlays.default];
+          in newPkgs.unison.lib.buildShareProject {
+            pname = "snake";
+            version = "0.0.4";
+            userHandle = "runarorama";
+            projectName = "terminus";
+
+            # The compiledHash is the hash of the compiled Unison code. This
+            # is needed because Nix builds restrict network access unless the
+            # output hash is known ahead of time (which helps with
+            # reproducibility and caching). You won't know it until you run
+            # the derivation for the first time. You can just set this to
+            # `pkgs.lib.fakeHash` and do a `nix build` or `nix run` and copy
+            # the hash labeled `got: `.
+            compiledHash = "sha256-6EnFUI5+9Zmyt7kDUjIvYR6q0Q4Ps5lNENZhghYuJJ0=";
+
+            # A mapping of executable names to Unison functions.
+            executables = {"snake" = "examples.snake.main";};
+          };
+        };
+
         formatter = pkgs.alejandra;
       }
     )

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,8 @@
       hash = "sha256-0HOLtLh1zRdaGQqchT5zFegWKJHkQe9r7DGKL6sSkPo=";
     };
 
-    localPackages = pkgs: let
+    local = {
+      packages = pkgs: let
       darwin-security-hack = pkgs.callPackage ./nix/darwin-security-hack.nix {};
     in {
       ucm = unison.packages.${pkgs.system}.default;
@@ -76,6 +77,21 @@
         hash = "sha256-PrbeIxhHWas35XfGnVSEMh4rH4uk+4Sls6syj4H29eQ=";
       };
     };
+
+      packagesLib = pkgs: let
+        buildFromTranscript =
+          pkgs.callPackage ./nix/build-from-transcript.nix {
+            ucm = (local.packages pkgs).ucm-bin;
+          };
+      in {
+        inherit buildFromTranscript;
+
+        buildShareProject =
+          pkgs.callPackage ./nix/build-share-project.nix {
+            inherit buildFromTranscript;
+          };
+      };
+    };
   in
     flake-utils.lib.eachSystem systems
     (
@@ -83,7 +99,8 @@
         pkgs = import nixpkgs {inherit system;};
       in {
         packages =
-          {default = self.packages.${system}.ucm-bin;} // localPackages pkgs;
+          {default = self.packages.${system}.ucm-bin;} // local.packages pkgs;
+        packagesLib = local.packagesLib pkgs;
 
         ## Deprecated
         defaultPackage = self.packages.${system}.default;
@@ -94,7 +111,7 @@
     // {
       overlays = {
         default = final: prev: let
-          localPkgs = localPackages final;
+          localPkgs = local.packages final;
         in {
           emacsPackagesFor = emacs:
             (prev.emacsPackagesFor emacs).overrideScope'
@@ -103,6 +120,8 @@
           tree-sitter = prev.tree-sitter.override {
             extraGrammars = self.overlays.tree-sitter final prev;
           };
+
+          unison.lib = local.packagesLib final;
 
           ## Renamed to replace the `unison-ucm` included in Nixpkgs.
           unison-ucm = localPkgs.ucm-bin;
@@ -153,7 +172,7 @@
         };
 
         vim = final: prev: vpkgs: let
-          localPkgs = localPackages final;
+          localPkgs = local.packages final;
         in {
           inherit (localPkgs) vim-unison;
 
@@ -167,7 +186,7 @@
         };
 
         vscode = final: prev: let
-          localPkgs = localPackages final;
+          localPkgs = local.packages final;
         in {
           TomSherman.unison-ui = localPkgs.vscode-ui;
           unison-lang.unison = localPkgs.vscode-lang;
@@ -177,19 +196,7 @@
       ## Deprecated
       overlay = self.overlays.default;
 
-      lib = let
-        buildUnisonFromTranscript = pkgs:
-          pkgs.callPackage ./nix/build-from-transcript.nix {
-            ucm = (localPackages pkgs).ucm-bin;
-          };
-      in {
-        inherit buildUnisonFromTranscript;
-
-        buildUnisonShareProject = pkgs:
-          pkgs.callPackage ./nix/build-share-project.nix {
-            buildUnisonFromTranscript = buildUnisonFromTranscript pkgs;
-          };
-
+      lib = {
         ## Emacs’s `treesit` package wants to pull grammars from Git repos, so
         ## this provides the Emacs Lisp form to pull the same grammer packaged
         ## in this flake.

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
     flake-utils.lib.eachSystem systems
     (
       system: let
-        pkgs = import nixpkgs {inherit system;};
+        pkgs = nixpkgs.legacyPackages.${system};
       in {
         packages =
           {default = self.packages.${system}.ucm-bin;} // local.packages pkgs;

--- a/nix/build-from-transcript.nix
+++ b/nix/build-from-transcript.nix
@@ -15,9 +15,8 @@
   ````nix
   src = builtins.toFile "pull-and-compile-http-server.md" ''
     ```ucm
-    .> project.create-empty tmp
-    tmp/main> pull @unison/httpserver/releases/3.0.2
-    tmp/main> compile examples.main unison-hello-server
+    scratch/main> pull @unison/httpserver/releases/3.0.2
+    scratch/main> compile examples.main unison-hello-server
     ```
     ''
   ````

--- a/nix/build-share-project.nix
+++ b/nix/build-share-project.nix
@@ -1,5 +1,5 @@
 {
-  buildUnisonFromTranscript,
+  buildFromTranscript,
   lib,
 }:
 /*
@@ -52,7 +52,7 @@ Compile functions from a project hosted on Unison Share into executables.
     ```
   '';
 in
-  buildUnisonFromTranscript {
+  buildFromTranscript {
     inherit pname version compiledHash meta;
 
     src = builtins.toFile "${pname}-compile-transcript-${version}.md" transcript;

--- a/nix/build-share-project.nix
+++ b/nix/build-share-project.nix
@@ -42,13 +42,12 @@ Compile functions from a project hosted on Unison Share into executables.
 } @ args: let
   compileCommands =
     lib.attrsets.mapAttrsToList
-    (executableName: functionName: "tmp/main> compile ${functionName} ${executableName}")
+    (executableName: functionName: "scratch/main> compile ${functionName} ${executableName}")
     executables;
 
   transcript = ''
     ```ucm
-    .> project.create-empty tmp
-    tmp/main> pull @${userHandle}/${projectName}/releases/${projectReleaseVersion}
+    scratch/main> pull @${userHandle}/${projectName}/releases/${projectReleaseVersion}
     ${lib.strings.concatStringsSep "\n" compileCommands}
     ```
   '';


### PR DESCRIPTION
The `buildUnisonFromTranscript` and `buildUnisonShareProject` functions used `.>` for the transcript UCM prompts, which is no longer supported. This updates them to `scratch/main>`[^1], and elides the project creation, which is now implicit.

[^1]: I changed the project from `tmp` to `scratch` just to match the transcript
convention.

Also, since clearly no one was using these functions, it seemed like a good time to put them in a semi-standard location, so they have been renamed

- `unison-nix.lib.buildUnisonFromTranscript pkgs` → `pkgs.unison.lib.buildFromTranscript` 
- `unison-nix.lib.buildUnisonShareProject pkgs` → `pkgs.unison.lib.buildShareProject`