### PR TITLE
Update `overrideScope` usage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -138,7 +138,7 @@
           localPkgs = local.packages final;
         in {
           emacsPackagesFor = emacs:
-            (prev.emacsPackagesFor emacs).overrideScope'
+            (prev.emacsPackagesFor emacs).overrideScope
             (self.overlays.emacs final prev);
 
           tree-sitter = prev.tree-sitter.override {


### PR DESCRIPTION
I’ve been getting “evaluation warning: `overrideScope'` (from `lib.makeScope`) has been renamed to `overrideScope`.” for a while, but couldn’t figure out where they were coming from. With Nixpkgs 25.05, it’s now an error, which made it easy to track down.