### PR TITLE
hostPlatform.system deprecation notice

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
       packages = pkgs: let
       darwin-security-hack = pkgs.callPackage ./nix/darwin-security-hack.nix {};
     in {
-      ucm = unison.packages.${pkgs.system}.default;
+      ucm = unison.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
       ucm-bin = pkgs.callPackage ./nix/ucm.nix {inherit darwin-security-hack;};
 

--- a/nix/ucm.nix
+++ b/nix/ucm.nix
@@ -39,7 +39,6 @@
   curl,
   openssl,
   stdenv,
-  system,
   zlib,
 }: let
   ## NB: When changing this, also change `inputs.unison.url` in flake.nix.

--- a/nix/ucm.nix
+++ b/nix/ucm.nix
@@ -67,7 +67,7 @@
   };
 
   src = let
-    srcArgs = srcForPlatform.${system};
+    srcArgs = srcForPlatform.${stdenv.hostPlatform.system};
   in
     fetchurl {
       url = "https://github.com/unisonweb/unison/releases/download/release/${version}/ucm-${srcArgs.sys}.tar.gz";


### PR DESCRIPTION
After upgrading to 25.11, I kept seeing:

> evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'

Tracked it down to my dependency on this flake, so here is the fix.

I tracked it down by doing:

```
NIX_ABORT_ON_WARN=true darwin-rebuild build --show-trace --flake .#Mac-David-Francoeur
```

From the super long trace, I saw (see ucm.nix towards the end):

<img width="802" height="398" alt="Screenshot 2025-12-14 at 6 27 51 PM" src="https://github.com/user-attachments/assets/04867fe8-51ef-4da7-90bc-720a38f4f282" />

More info:
https://discourse.nixos.org/t/how-to-fix-evaluation-warning-system-has-been-renamed-to-replaced-by-stdenv-hostplatform-system/72120/1