### PR TITLE
Allow src folder inclusion when running transcript

### DIFF
--- a/nix/build-from-transcript.nix
+++ b/nix/build-from-transcript.nix
@@ -8,12 +8,17 @@
   pname,
   version,
   /*
+  A folder with additional sources you may like to use when evaluating your
+  transcript file.
+  */
+  src,
+  /*
   A Unison transcript file. The transcript should use the ucm `compile` command to compile any desired executables into the working directory.
 
   # Examples
 
   ````nix
-  src = builtins.toFile "pull-and-compile-http-server.md" ''
+  transcript = builtins.toFile "pull-and-compile-http-server.md" ''
     ```ucm
     scratch/main> pull @unison/httpserver/releases/3.0.2
     scratch/main> compile examples.main unison-hello-server
@@ -21,7 +26,7 @@
     ''
   ````
   */
-  src,
+  transcript,
   /*
   The compiledHash is the hash of the compiled Unison code. This is needed
   because Nix builds restrict network access unless the output hash is known
@@ -35,13 +40,14 @@
 }: let
   compiled = stdenv.mkDerivation {
     # include the ucm version and transcript hash in the derivation name so it is rebuilt if either changes
-    pname = pname + "_ucm-${ucm.version}_${builtins.hashFile "sha256" src}";
+    pname = pname + "_ucm-${ucm.version}_${builtins.hashFile "sha256" transcript}";
     inherit version;
 
     nativeBuildInputs = [cacert];
     buildCommand = ''
       export XDG_DATA_HOME="$TMP/.local/share"
-      ${ucm}/bin/ucm -C . transcript ${src}
+      cp -r ${src}/. .
+      ${ucm}/bin/ucm -C . transcript ${transcript}
       mkdir -p $out/share
       mv *.uc $out/share/
     '';

--- a/nix/build-share-project.nix
+++ b/nix/build-share-project.nix
@@ -45,7 +45,7 @@ Compile functions from a project hosted on Unison Share into executables.
     (executableName: functionName: "scratch/main> compile ${functionName} ${executableName}")
     executables;
 
-  transcript = ''
+  transcriptContents = ''
     ```ucm
     scratch/main> pull @${userHandle}/${projectName}/releases/${projectReleaseVersion}
     ${lib.strings.concatStringsSep "\n" compileCommands}
@@ -55,5 +55,5 @@ in
   buildFromTranscript {
     inherit pname version compiledHash meta;
 
-    src = builtins.toFile "${pname}-compile-transcript-${version}.md" transcript;
+    transcript = builtins.toFile "${pname}-compile-transcript-${version}.md" transcriptContents;
   }


### PR DESCRIPTION
A simple change to allow for including extra files when running the transcript; this reduces the need to have every single statement defined in the transcript file itself, and lets you have multiple `.u` files that you load in.

Fixes #153 .