### PR TITLE
Update to Unison 1.3.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,105 +1,5 @@
 {
   "nodes": {
-    "HTTP": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1451647621,
-        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
-        "owner": "phadej",
-        "repo": "HTTP",
-        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
-        "type": "github"
-      },
-      "original": {
-        "owner": "phadej",
-        "repo": "HTTP",
-        "type": "github"
-      }
-    },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-34": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645834128,
-        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.4",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-36": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1669081697,
-        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cardano-shell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1608537748,
-        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1672831974,
-        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "hkm/gitlab-fix",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -115,244 +15,6 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
-    "hackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1719535035,
-        "narHash": "sha256-kCCfZytGgkRYlsiNe/dwLAnpNOvfywpjVl61hO/8l2M=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "66f23365685f71610460f3c2c0dfa91f96c532ac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
-    "haskellNix": {
-      "inputs": {
-        "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
-        "cabal-34": "cabal-34",
-        "cabal-36": "cabal-36",
-        "cardano-shell": "cardano-shell",
-        "flake-compat": "flake-compat",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "hackage": "hackage",
-        "hls-1.10": "hls-1.10",
-        "hls-2.0": "hls-2.0",
-        "hls-2.2": "hls-2.2",
-        "hls-2.3": "hls-2.3",
-        "hls-2.4": "hls-2.4",
-        "hls-2.5": "hls-2.5",
-        "hls-2.6": "hls-2.6",
-        "hls-2.7": "hls-2.7",
-        "hls-2.8": "hls-2.8",
-        "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
-        "iserv-proxy": "iserv-proxy",
-        "nixpkgs": [
-          "unison",
-          "haskellNix",
-          "nixpkgs-unstable"
-        ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
-        "nixpkgs-2305": "nixpkgs-2305",
-        "nixpkgs-2311": "nixpkgs-2311",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "old-ghc-nix": "old-ghc-nix",
-        "stackage": "stackage"
-      },
-      "locked": {
-        "lastModified": 1719535822,
-        "narHash": "sha256-IteIKK4+GEZI2nHqCz0zRVgQ3aqs/WXKTOt2sbHJmGk=",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "72bc84d0a4e8d0536505628040d96fd0a9e16c70",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "type": "github"
-      }
-    },
-    "hls-1.10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1680000865,
-        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "1.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.0": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1687698105,
-        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "783905f211ac63edf982dd1889c671653327e441",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.0.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1693064058,
-        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.2.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1695910642,
-        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.3.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1699862708,
-        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.4.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1701080174,
-        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.5.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.6": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1705325287,
-        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.6.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.7": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1708965829,
-        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.7.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.8": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1715153580,
-        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.8.0.0",
-        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -377,100 +39,6 @@
         "type": "github"
       }
     },
-    "hpc-coveralls": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1607498076,
-        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "type": "github"
-      }
-    },
-    "hydra": {
-      "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "unison",
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
-    "iserv-proxy": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1717479972,
-        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
-        "owner": "stable-haskell",
-        "repo": "iserv-proxy",
-        "rev": "2ed34002247213fc435d0062350b91bab920626e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "stable-haskell",
-        "ref": "iserv-syms",
-        "repo": "iserv-proxy",
-        "type": "github"
-      }
-    },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1770464364,
@@ -487,196 +55,19 @@
         "type": "github"
       }
     },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2305": {
-      "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2311": {
-      "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-release": {
-      "locked": {
-        "lastModified": 1719520878,
-        "narHash": "sha256-5BXzNOl2RVHcfS/oxaZDKOi7gVuTyWPibQG0DHd5sSc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a44bedbb48c367f0476e6a3a27bf28f6330faf23",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "lastModified": 1767480499,
+        "narHash": "sha256-8IQQUorUGiSmFaPnLSo2+T+rjHtiNWc+OAzeHck7N48=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "30a3c519afcf3f99e2c6df3b359aec5692054d92",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05-small",
+        "ref": "nixpkgs-25.11-darwin",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "old-ghc-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1631092763,
-        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
-        "owner": "angerman",
-        "repo": "old-ghc-nix",
-        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "angerman",
-        "ref": "master",
-        "repo": "old-ghc-nix",
         "type": "github"
       }
     },
@@ -688,19 +79,19 @@
         "unison": "unison"
       }
     },
-    "stackage": {
-      "flake": false,
+    "stacklock2nix": {
       "locked": {
-        "lastModified": 1719102283,
-        "narHash": "sha256-pon+cXgMWPlCiBx9GlRcjsjTHbCc8fDVgOGb3Z7qhRM=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "7df45e0bd9852810d8070f9c5257f8e7a4677b91",
+        "lastModified": 1758881683,
+        "narHash": "sha256-GZDAUJ3RGOjxB0KRbQMPZNQ0uTQKqcyQeVLyN8CrJtQ=",
+        "owner": "cdepillabout",
+        "repo": "stacklock2nix",
+        "rev": "246cae921545dfb340ba5776f2962bc5c2692097",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
+        "owner": "cdepillabout",
+        "ref": "v5.2.1",
+        "repo": "stacklock2nix",
         "type": "github"
       }
     },
@@ -724,13 +115,8 @@
         "flake-utils": [
           "flake-utils"
         ],
-        "haskellNix": "haskellNix",
-        "nixpkgs": [
-          "unison",
-          "haskellNix",
-          "nixpkgs-unstable"
-        ],
-        "nixpkgs-release": "nixpkgs-release",
+        "nixpkgs": "nixpkgs_2",
+        "stacklock2nix": "stacklock2nix",
         "systems": [
           "unison",
           "flake-utils",
@@ -738,16 +124,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1769618968,
-        "narHash": "sha256-0Y5pNjULsIJ6r3VaMYLrLT/iXpmZvQLX9q1C0siED7o=",
+        "lastModified": 1778686127,
+        "narHash": "sha256-uw1QBTY6Shj2liDdLaoNjqkEAYr5pMG7SfrLuhdDi8k=",
         "owner": "unisonweb",
         "repo": "unison",
-        "rev": "4ff37ee6a0bd0afbea7aedbe04eed76e79fcba8c",
+        "rev": "0452fcab2635cdbf0d1f717812a1168d300ebbcb",
         "type": "github"
       },
       "original": {
         "owner": "unisonweb",
-        "ref": "release/1.1.0",
+        "ref": "release/1.3.0",
         "repo": "unison",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
       ## NB: Before upgrading this, make sure the release you upgrade to is
       ##     pinned in the cache (https://app.cachix.org/cache/unison#pins) for
       ##     all supported systems.
-      url = "github:unisonweb/unison/release/1.1.0";
+      url = "github:unisonweb/unison/release/1.3.0";
     };
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -46,40 +46,44 @@
     local = {
       packages = pkgs: let
         darwin-security-hack = pkgs.callPackage ./nix/darwin-security-hack.nix {};
-      in {
-        ucm = unison.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      in
+        {
+          ucm = unison.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
-        ucm-bin = pkgs.callPackage ./nix/ucm.nix {inherit darwin-security-hack;};
+          ucm-bin = pkgs.callPackage ./nix/ucm.nix {inherit darwin-security-hack;};
 
-        ucm-desktop = pkgs.callPackage ./nix/ucm-desktop {};
+          tree-sitter-grammar = pkgs.tree-sitter.buildGrammar {
+            language = "unison";
+            version = tree-sitter-unison-github.rev;
+            src = pkgs.fetchFromGitHub tree-sitter-unison-github;
+          };
 
-        tree-sitter-grammar = pkgs.tree-sitter.buildGrammar {
-          language = "unison";
-          version = tree-sitter-unison-github.rev;
-          src = pkgs.fetchFromGitHub tree-sitter-unison-github;
-        };
+          ## TODO: Move this to Unison proper, and then just re-export it from here.
+          ##       Then we can avoid the non-flake usage of the Unison flake.
+          vim-unison = pkgs.vimUtils.buildVimPlugin {
+            name = "vim-unison";
+            src = unison + "/editor-support/vim";
+          };
 
-        ## TODO: Move this to Unison proper, and then just re-export it from here.
-        ##       Then we can avoid the non-flake usage of the Unison flake.
-        vim-unison = pkgs.vimUtils.buildVimPlugin {
-          name = "vim-unison";
-          src = unison + "/editor-support/vim";
-        };
+          vscode-lang = pkgs.vscode-utils.extensionFromVscodeMarketplace {
+            name = "unison";
+            publisher = "unison-lang";
+            version = "1.2.0";
+            hash = "sha256-ulm3a1xJxtk+SIQP1sByEqgajd1a4P3oEfVgxoF5GcQ=";
+          };
 
-        vscode-lang = pkgs.vscode-utils.extensionFromVscodeMarketplace {
-          name = "unison";
-          publisher = "unison-lang";
-          version = "1.2.0";
-          hash = "sha256-ulm3a1xJxtk+SIQP1sByEqgajd1a4P3oEfVgxoF5GcQ=";
-        };
-
-        vscode-ui = pkgs.vscode-utils.extensionFromVscodeMarketplace {
-          name = "unison-ui";
-          publisher = "TomSherman";
-          version = "0.1.5";
-          hash = "sha256-PrbeIxhHWas35XfGnVSEMh4rH4uk+4Sls6syj4H29eQ=";
-        };
-      };
+          vscode-ui = pkgs.vscode-utils.extensionFromVscodeMarketplace {
+            name = "unison-ui";
+            publisher = "TomSherman";
+            version = "0.1.5";
+            hash = "sha256-PrbeIxhHWas35XfGnVSEMh4rH4uk+4Sls6syj4H29eQ=";
+          };
+        }
+        // (
+          if pkgs.stdenv.isLinux
+          then {ucm-desktop = pkgs.callPackage ./nix/ucm-desktop {};}
+          else {}
+        );
 
       packagesLib = pkgs: let
         buildFromTranscript = pkgs.callPackage ./nix/build-from-transcript.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Support for the Unison programming language";
 
-   nixConfig = {
+  nixConfig = {
     extra-substituters = ["https://unison.cachix.org"];
     extra-trusted-public-keys = [
       "unison.cachix.org-1:i1DUFkisRPVOyLp/vblDsbsObmyCviq/zs6eRuzth3k="
@@ -44,54 +44,52 @@
 
     local = {
       packages = pkgs: let
-      darwin-security-hack = pkgs.callPackage ./nix/darwin-security-hack.nix {};
-    in {
-      ucm = unison.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        darwin-security-hack = pkgs.callPackage ./nix/darwin-security-hack.nix {};
+      in {
+        ucm = unison.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
-      ucm-bin = pkgs.callPackage ./nix/ucm.nix {inherit darwin-security-hack;};
+        ucm-bin = pkgs.callPackage ./nix/ucm.nix {inherit darwin-security-hack;};
 
-      ucm-desktop = pkgs.callPackage ./nix/ucm-desktop {};
+        ucm-desktop = pkgs.callPackage ./nix/ucm-desktop {};
 
-      tree-sitter-grammar = pkgs.tree-sitter.buildGrammar {
-        language = "unison";
-        version = tree-sitter-unison-github.rev;
-        src = pkgs.fetchFromGitHub tree-sitter-unison-github;
+        tree-sitter-grammar = pkgs.tree-sitter.buildGrammar {
+          language = "unison";
+          version = tree-sitter-unison-github.rev;
+          src = pkgs.fetchFromGitHub tree-sitter-unison-github;
+        };
+
+        ## TODO: Move this to Unison proper, and then just re-export it from here.
+        ##       Then we can avoid the non-flake usage of the Unison flake.
+        vim-unison = pkgs.vimUtils.buildVimPlugin {
+          name = "vim-unison";
+          src = unison + "/editor-support/vim";
+        };
+
+        vscode-lang = pkgs.vscode-utils.extensionFromVscodeMarketplace {
+          name = "unison";
+          publisher = "unison-lang";
+          version = "1.2.0";
+          hash = "sha256-ulm3a1xJxtk+SIQP1sByEqgajd1a4P3oEfVgxoF5GcQ=";
+        };
+
+        vscode-ui = pkgs.vscode-utils.extensionFromVscodeMarketplace {
+          name = "unison-ui";
+          publisher = "TomSherman";
+          version = "0.1.5";
+          hash = "sha256-PrbeIxhHWas35XfGnVSEMh4rH4uk+4Sls6syj4H29eQ=";
+        };
       };
-
-      ## TODO: Move this to Unison proper, and then just re-export it from here.
-      ##       Then we can avoid the non-flake usage of the Unison flake.
-      vim-unison = pkgs.vimUtils.buildVimPlugin {
-        name = "vim-unison";
-        src = unison + "/editor-support/vim";
-      };
-
-      vscode-lang = pkgs.vscode-utils.extensionFromVscodeMarketplace {
-        name = "unison";
-        publisher = "unison-lang";
-        version = "1.2.0";
-        hash = "sha256-ulm3a1xJxtk+SIQP1sByEqgajd1a4P3oEfVgxoF5GcQ=";
-      };
-
-      vscode-ui = pkgs.vscode-utils.extensionFromVscodeMarketplace {
-        name = "unison-ui";
-        publisher = "TomSherman";
-        version = "0.1.5";
-        hash = "sha256-PrbeIxhHWas35XfGnVSEMh4rH4uk+4Sls6syj4H29eQ=";
-      };
-    };
 
       packagesLib = pkgs: let
-        buildFromTranscript =
-          pkgs.callPackage ./nix/build-from-transcript.nix {
-            ucm = (local.packages pkgs).ucm-bin;
-          };
+        buildFromTranscript = pkgs.callPackage ./nix/build-from-transcript.nix {
+          ucm = (local.packages pkgs).ucm-bin;
+        };
       in {
         inherit buildFromTranscript;
 
-        buildShareProject =
-          pkgs.callPackage ./nix/build-share-project.nix {
-            inherit buildFromTranscript;
-          };
+        buildShareProject = pkgs.callPackage ./nix/build-share-project.nix {
+          inherit buildFromTranscript;
+        };
       };
     };
   in
@@ -111,24 +109,25 @@
           # A simple example: create an executable from a Unison Share project
           snake = let
             newPkgs = pkgs.appendOverlays [self.overlays.default];
-          in newPkgs.unison.lib.buildShareProject {
-            pname = "snake";
-            version = "0.0.4";
-            userHandle = "runarorama";
-            projectName = "terminus";
+          in
+            newPkgs.unison.lib.buildShareProject {
+              pname = "snake";
+              version = "0.0.4";
+              userHandle = "runarorama";
+              projectName = "terminus";
 
-            # The compiledHash is the hash of the compiled Unison code. This
-            # is needed because Nix builds restrict network access unless the
-            # output hash is known ahead of time (which helps with
-            # reproducibility and caching). You won't know it until you run
-            # the derivation for the first time. You can just set this to
-            # `pkgs.lib.fakeHash` and do a `nix build` or `nix run` and copy
-            # the hash labeled `got: `.
-            compiledHash = "sha256-hu0FC3/my8dFTboLxcPDQhIjxDAhzZZPDqgUVmZ2qQY=";
+              # The compiledHash is the hash of the compiled Unison code. This
+              # is needed because Nix builds restrict network access unless the
+              # output hash is known ahead of time (which helps with
+              # reproducibility and caching). You won't know it until you run
+              # the derivation for the first time. You can just set this to
+              # `pkgs.lib.fakeHash` and do a `nix build` or `nix run` and copy
+              # the hash labeled `got: `.
+              compiledHash = "sha256-hu0FC3/my8dFTboLxcPDQhIjxDAhzZZPDqgUVmZ2qQY=";
 
-            # A mapping of executable names to Unison functions.
-            executables = {"snake" = "examples.snake.main";};
-          };
+              # A mapping of executable names to Unison functions.
+              executables = {"snake" = "examples.snake.main";};
+            };
         };
 
         formatter = pkgs.alejandra;

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "Support for the Unison programming language";
 
   nixConfig = {
+    allow-import-from-derivation = true;
     extra-substituters = ["https://unison.cachix.org"];
     extra-trusted-public-keys = [
       "unison.cachix.org-1:i1DUFkisRPVOyLp/vblDsbsObmyCviq/zs6eRuzth3k="


### PR DESCRIPTION
It was previously on 1.1.0. 1.2.0 (IIRC) switched to the simpler Nix infrastructure, so this discards a lot of haskell.nix cruft (as you can see from the ~650 lines removed from flake.lock).

This also makes a couple other minor fixes:
- only expose ucm-desktop on Linux
- be explicit about requiring IFD in the flake